### PR TITLE
1.0.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 jar.archiveName = project.name + '.jar'
 // Add SNAPSHOT to make this publish as a beta.
-version '1.0.8'
+version '1.0.8.1-SNAPSHOT'
 
 sourceCompatibility = 1.8
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 jar.archiveName = project.name + '.jar'
 // Add SNAPSHOT to make this publish as a beta.
-version '1.0.8.2-SNAPSHOT'
+version '1.0.9'
 
 sourceCompatibility = 1.8
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 jar.archiveName = project.name + '.jar'
 // Add SNAPSHOT to make this publish as a beta.
-version '1.0.8.1-SNAPSHOT'
+version '1.0.8.2-SNAPSHOT'
 
 sourceCompatibility = 1.8
 

--- a/src/main/java/com/sitrica/japson/client/JapsonClient.java
+++ b/src/main/java/com/sitrica/japson/client/JapsonClient.java
@@ -99,6 +99,7 @@ public class JapsonClient extends Japson {
 				out.writeUTF(gson.toJson(japsonPacket.toJson()));
 				byte[] buf = out.toByteArray();
 				DatagramPacket packet = new DatagramPacket(buf, buf.length, address, port);
+				socket.setSoTimeout(5000);
 				socket.send(packet);
 				// Reset the byte buffer
 				buf = new byte[PACKET_SIZE];
@@ -132,7 +133,7 @@ public class JapsonClient extends Japson {
 						.log("Timeout: " + exception.getMessage());
 			}
 			return null;
-		}).get(HEARTBEAT * 5, TimeUnit.SECONDS);
+		}).get(HEARTBEAT * 3, TimeUnit.SECONDS);
 	}
 
 	public void sendPacket(Packet japsonPacket) {
@@ -142,6 +143,7 @@ public class JapsonClient extends Japson {
 				out.writeInt(japsonPacket.getID());
 				out.writeUTF(gson.toJson(japsonPacket.toJson()));
 				byte[] buf = out.toByteArray();
+				socket.setSoTimeout(5000);
 				socket.send(new DatagramPacket(buf, buf.length, address, port));
 				if (debug)
 					logger.atInfo().log("Sent non-returnable packet with id %s", japsonPacket.getID());

--- a/src/main/java/com/sitrica/japson/client/JapsonClient.java
+++ b/src/main/java/com/sitrica/japson/client/JapsonClient.java
@@ -62,7 +62,7 @@ public class JapsonClient extends Japson {
 	public JapsonClient(InetAddress address, int port, Gson gson) {
 		super(address, port);
 		this.gson = gson;
-		HeartbeatPacket packet = new HeartbeatPacket(password);
+		HeartbeatPacket packet = new HeartbeatPacket(password, port);
 		executor.scheduleAtFixedRate(() -> sendPacket(packet), DELAY, HEARTBEAT, TimeUnit.MILLISECONDS);
 		if (debug)
 			logger.atInfo().log("Started Japson client bound to %s.", address.getHostAddress() + ":" + port);

--- a/src/main/java/com/sitrica/japson/client/JapsonClient.java
+++ b/src/main/java/com/sitrica/japson/client/JapsonClient.java
@@ -99,7 +99,6 @@ public class JapsonClient extends Japson {
 				out.writeUTF(gson.toJson(japsonPacket.toJson()));
 				byte[] buf = out.toByteArray();
 				DatagramPacket packet = new DatagramPacket(buf, buf.length, address, port);
-				socket.setSoTimeout(5000);
 				socket.send(packet);
 				// Reset the byte buffer
 				buf = new byte[PACKET_SIZE];
@@ -133,7 +132,7 @@ public class JapsonClient extends Japson {
 						.log("Timeout: " + exception.getMessage());
 			}
 			return null;
-		}).get(HEARTBEAT * 3, TimeUnit.SECONDS);
+		}).get(HEARTBEAT * 3, TimeUnit.MILLISECONDS);
 	}
 
 	public void sendPacket(Packet japsonPacket) {
@@ -143,7 +142,7 @@ public class JapsonClient extends Japson {
 				out.writeInt(japsonPacket.getID());
 				out.writeUTF(gson.toJson(japsonPacket.toJson()));
 				byte[] buf = out.toByteArray();
-				socket.setSoTimeout(5000);
+				socket.setSoTimeout((int)(HEARTBEAT * 3));
 				socket.send(new DatagramPacket(buf, buf.length, address, port));
 				if (debug)
 					logger.atInfo().log("Sent non-returnable packet with id %s", japsonPacket.getID());

--- a/src/main/java/com/sitrica/japson/client/packets/HeartbeatPacket.java
+++ b/src/main/java/com/sitrica/japson/client/packets/HeartbeatPacket.java
@@ -6,10 +6,12 @@ import com.sitrica.japson.shared.Packet;
 public class HeartbeatPacket extends Packet {
 
 	private final String password;
+	private final int port;
 
-	public HeartbeatPacket(String password) {
+	public HeartbeatPacket(String password, int port) {
 		super(0x00);
 		this.password = password;
+		this.port = port;
 	}
 
 	@Override
@@ -17,6 +19,7 @@ public class HeartbeatPacket extends Packet {
 		JsonObject object = new JsonObject();
 		if (password != null)
 			object.addProperty("password", password);
+		object.addProperty("port", port);
 		return object;
 	}
 

--- a/src/main/java/com/sitrica/japson/server/Connections.java
+++ b/src/main/java/com/sitrica/japson/server/Connections.java
@@ -27,7 +27,7 @@ public class Connections extends Executor {
 	private final JapsonServer japson;
 
 	public Connections(JapsonServer japson) {
-		super((byte) 0x00);
+		super(0x00);
 		this.japson = japson;
 		disconnected = CacheBuilder.newBuilder()
 				.expireAfterWrite(japson.getExpiry(), TimeUnit.MINUTES)
@@ -97,7 +97,8 @@ public class Connections extends Executor {
 	}
 
 	@Override
-	public void execute(InetAddress address, int port, JsonObject json) {
+	public void execute(InetAddress address, int packetPort, JsonObject json) {
+		int port = json.get("port").getAsInt();
 		if (!japson.hasPassword()) {
 			JapsonConnection connection = addConnection(address, port);
 			connection.update();

--- a/src/main/java/com/sitrica/japson/server/JapsonServer.java
+++ b/src/main/java/com/sitrica/japson/server/JapsonServer.java
@@ -4,6 +4,7 @@ import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -20,6 +21,7 @@ public class JapsonServer extends Japson {
 	private static final ExecutorService executor = Executors.newCachedThreadPool();
 	private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 	protected final Set<Listener> listeners = new HashSet<>();
+	private final Set<Integer> ignored = new HashSet<>();
 
 	private long TIMEOUT = 3000L, HEARTBEAT = 1000L, DISCONNECT = 5, EXPIRY = 10; // EXPIRY in minutes, DISCONNECT is amount, and rest in milliseconds.
 	private final Connections connections;
@@ -76,6 +78,10 @@ public class JapsonServer extends Japson {
 		return registerListeners(listener);
 	}
 
+	public void addIgnoreDebugPackets(Integer... packets) {
+		ignored.addAll(Sets.newHashSet(packets));
+	}
+
 	/**
 	 * The amount of minutes to wait before forgetting about a connection.
 	 * 
@@ -95,6 +101,10 @@ public class JapsonServer extends Japson {
 	public JapsonServer setTimeout(long timeout) {
 		this.TIMEOUT = timeout;
 		return this;
+	}
+
+	public Set<Integer> getIgnoredPackets() {
+		return Collections.unmodifiableSet(ignored);
 	}
 
 	public long getMaxDisconnectAttempts() {

--- a/src/main/java/com/sitrica/japson/server/SocketHandler.java
+++ b/src/main/java/com/sitrica/japson/server/SocketHandler.java
@@ -59,7 +59,7 @@ public class SocketHandler implements Runnable {
 					japson.getLogger().atSevere().log("Recieved packet with id %s and the json was null.", id);
 					return;
 				}
-				if (japson.isDebug())
+				if (japson.isDebug() && !japson.getIgnoredPackets().contains(id))
 					japson.getLogger().atInfo().log("Recieved packet with id %s and data %s", id, data);
 				// Handle
 				JsonObject object = JsonParser.parseString(data).getAsJsonObject();

--- a/src/main/java/com/sitrica/japson/shared/Executor.java
+++ b/src/main/java/com/sitrica/japson/shared/Executor.java
@@ -21,7 +21,7 @@ public abstract class Executor extends Handler {
 	public abstract void execute(InetAddress address, int port, JsonObject json);
 
 	@Override
-	public JsonObject handle(InetAddress address, int port, JsonObject json) {
+	public final JsonObject handle(InetAddress address, int port, JsonObject json) {
 		execute(address, port, json);
 		return null;
 	}


### PR DESCRIPTION
- Fixed the heartbeat and JapsonConnections taking into account the correct port.
- Fixed Heartbeat being in seconds rather than milliseconds.
- Added a timeout for the sockets.
- Added a method to add ignored packets in the debug for the JapsonServer.