### PR TITLE
1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 jar.archiveName = project.name + '.jar'
 // Add SNAPSHOT to make this publish as a beta.
-version '1.0.9'
+version '1.1.0'
 
 sourceCompatibility = 1.8
 

--- a/src/main/java/com/sitrica/japson/client/JapsonClient.java
+++ b/src/main/java/com/sitrica/japson/client/JapsonClient.java
@@ -1,35 +1,24 @@
 package com.sitrica.japson.client;
 
-import java.io.IOException;
-import java.net.DatagramPacket;
-import java.net.DatagramSocket;
 import java.net.InetAddress;
-import java.net.SocketException;
 import java.net.UnknownHostException;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import com.google.common.flogger.FluentLogger;
-import com.google.common.io.ByteArrayDataInput;
-import com.google.common.io.ByteArrayDataOutput;
-import com.google.common.io.ByteStreams;
+import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonParser;
 import com.sitrica.japson.client.packets.HeartbeatPacket;
 import com.sitrica.japson.shared.Japson;
 import com.sitrica.japson.shared.Packet;
-import com.sitrica.japson.shared.ReceiverFuture;
 import com.sitrica.japson.shared.ReturnablePacket;
 
 public class JapsonClient extends Japson {
 
 	private static final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
-	private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
 	protected long HEARTBEAT = 1000L, DELAY = 1000L; // in milliseconds.
 
@@ -79,10 +68,6 @@ public class JapsonClient extends Japson {
 		return this;
 	}
 
-	public FluentLogger getLogger() {
-		return logger;
-	}
-
 	public void shutdown() {
 		executor.shutdown();
 	}
@@ -91,71 +76,37 @@ public class JapsonClient extends Japson {
 		executor.shutdownNow();
 	}
 
+	@Override
+	public JapsonClient setAllowedAddresses(InetAddress... addesses) {
+		acceptable.clear();
+		acceptable.addAll(Sets.newHashSet(addesses));
+		return this;
+	}
+
+	@Override
+	public JapsonClient setPacketBufferSize(int buffer) {
+		this.PACKET_SIZE = buffer;
+		return this;
+	}
+
+	@Override
+	public JapsonClient setPassword(String password) {
+		this.password = password;
+		return this;
+	}
+
+	@Override
+	public JapsonClient enableDebug() {
+		this.debug = true;
+		return this;
+	}
+
 	public <T> T sendPacket(ReturnablePacket<T> japsonPacket) throws TimeoutException, InterruptedException, ExecutionException {
-		return CompletableFuture.supplyAsync(() -> {
-			try (DatagramSocket socket = new DatagramSocket()) {
-				ByteArrayDataOutput out = ByteStreams.newDataOutput();
-				out.writeInt(japsonPacket.getID());
-				out.writeUTF(gson.toJson(japsonPacket.toJson()));
-				byte[] buf = out.toByteArray();
-				DatagramPacket packet = new DatagramPacket(buf, buf.length, address, port);
-				socket.send(packet);
-				// Reset the byte buffer
-				buf = new byte[PACKET_SIZE];
-				ByteArrayDataInput input = new ReceiverFuture(logger, this, socket)
-						.create(new DatagramPacket(buf, buf.length))
-						.get();
-				if (input == null) {
-					logger.atSevere().log("Packet with id %s returned null or an incorrect readable object for Japson", japsonPacket.getID());
-					return null;
-				}
-				int id = input.readInt();
-				if (id != japsonPacket.getID()) {
-					logger.atSevere().log("Sent returnable packet with id %s, but did not get correct packet id returned", japsonPacket.getID());
-					return null;
-				}
-				String json = input.readUTF();
-				if (debug)
-					logger.atInfo().log("Sent returnable packet with id %s and recieved %s", japsonPacket.getID(), json);
-				return japsonPacket.getObject(JsonParser.parseString(json).getAsJsonObject());
-			} catch (SocketException socketException) {
-				logger.atSevere().withCause(socketException)
-						.atMostEvery(15, TimeUnit.SECONDS)
-						.log("Socket error: " + socketException.getMessage());
-			} catch (IOException exception) {
-				logger.atSevere().withCause(exception)
-						.atMostEvery(15, TimeUnit.SECONDS)
-						.log("IO error: " + exception.getMessage());
-			} catch (InterruptedException | ExecutionException exception) {
-				logger.atSevere().withCause(exception)
-						.atMostEvery(15, TimeUnit.SECONDS)
-						.log("Timeout: " + exception.getMessage());
-			}
-			return null;
-		}).get(HEARTBEAT * 3, TimeUnit.MILLISECONDS);
+		return sendPacket(address, port, japsonPacket, gson);
 	}
 
 	public void sendPacket(Packet japsonPacket) {
-		CompletableFuture.runAsync(() -> {
-			try (DatagramSocket socket = new DatagramSocket()) {
-				ByteArrayDataOutput out = ByteStreams.newDataOutput();
-				out.writeInt(japsonPacket.getID());
-				out.writeUTF(gson.toJson(japsonPacket.toJson()));
-				byte[] buf = out.toByteArray();
-				socket.setSoTimeout((int)(HEARTBEAT * 3));
-				socket.send(new DatagramPacket(buf, buf.length, address, port));
-				if (debug)
-					logger.atInfo().log("Sent non-returnable packet with id %s", japsonPacket.getID());
-			} catch (SocketException socketException) {
-				logger.atSevere().withCause(socketException)
-						.atMostEvery(15, TimeUnit.SECONDS)
-						.log("Socket error: " + socketException.getMessage());
-			} catch (IOException exception) {
-				logger.atSevere().withCause(exception)
-						.atMostEvery(15, TimeUnit.SECONDS)
-						.log("IO error: " + exception.getMessage());
-			}
-		});
+		sendPacket(address, port, japsonPacket, gson);
 	}
 
 }

--- a/src/main/java/com/sitrica/japson/server/JapsonServer.java
+++ b/src/main/java/com/sitrica/japson/server/JapsonServer.java
@@ -82,6 +82,31 @@ public class JapsonServer extends Japson {
 		ignored.addAll(Sets.newHashSet(packets));
 	}
 
+	@Override
+	public JapsonServer setAllowedAddresses(InetAddress... addesses) {
+		acceptable.clear();
+		acceptable.addAll(Sets.newHashSet(addesses));
+		return this;
+	}
+
+	@Override
+	public JapsonServer setPacketBufferSize(int buffer) {
+		this.PACKET_SIZE = buffer;
+		return this;
+	}
+
+	@Override
+	public JapsonServer setPassword(String password) {
+		this.password = password;
+		return this;
+	}
+
+	@Override
+	public JapsonServer enableDebug() {
+		this.debug = true;
+		return this;
+	}
+
 	/**
 	 * The amount of minutes to wait before forgetting about a connection.
 	 * 


### PR DESCRIPTION
- Made sendPacket methods for single fire and forget packets (QUIC style)
- The chaining methods returning the JapsonClient or JapsonServer object, are now present for the main setup methods to make a chaining.